### PR TITLE
Fix: Protected endpoint no longer require explicit user_id

### DIFF
--- a/chari-spot/backend/src/app/auth.py
+++ b/chari-spot/backend/src/app/auth.py
@@ -10,9 +10,10 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from models import user as user_model
+from crud import user as user_crud
 
 # Secret for JWT (keep this safe!)
-SECRET_KEY = "your-very-long-random-string"
+SECRET_KEY = "lasgagasdgzasdflkasdivnadflaszc_dasdfha"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 
@@ -29,7 +30,7 @@ def get_password_hash(password: str) -> str:
 
 
 def authenticate_user(db: Session, email: str, password: str):
-    user = db.query(user_model.User).filter(user_model.User.email == email).first()
+    user = user_crud.get_user_by_email(db, email)
     if not user or not verify_password(password, user.password):
         return None
     return user
@@ -37,7 +38,7 @@ def authenticate_user(db: Session, email: str, password: str):
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    expire = datetime.now() + (expires_delta or timedelta(minutes=15))
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
@@ -45,7 +46,7 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
 async def get_current_user(
     token: str = Depends(oauth2_scheme),
     db: Session = Depends(get_db)
-):
+)-> user_model.User:
     credentials_exc = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid authentication credentials",
@@ -53,13 +54,13 @@ async def get_current_user(
     )
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        email: str = payload.get("sub")
-        if not email:
+        u_id: int = payload.get("user_id")
+        if not u_id:
             raise credentials_exc
     except JWTError:
         raise credentials_exc
 
-    user = db.query(user_model.User).filter(user_model.User.email == email).first()
+    user = user_crud.get_user(db, u_id)
     if not user:
         raise credentials_exc
     return user

--- a/chari-spot/backend/src/crud/parking.py
+++ b/chari-spot/backend/src/crud/parking.py
@@ -18,6 +18,10 @@ def get_parking(db: Session, id: int) -> Optional[parking.Parking]:
 def get_parkings(db: Session, skip: int = 0, limit: int = 100):
     return db.query(parking.Parking).offset(skip).limit(limit).all()
 
+def get_parking_by_owner(db: Session, u_id: int) -> Optional[list[parking.Parking]]:
+    """Fetch a list of slots by owner ID."""
+    return db.query(parking.Parking).filter(parking.Parking.owner_id == u_id).all()
+
 def update_slot(db: Session, slotUpdate: ParkingUpdate) -> Optional[parking.Parking]:
     """Update fields on a slot. Returns the updated slot, or None if not found."""
     slot = get_parking(db, slotUpdate.id)
@@ -42,4 +46,3 @@ def delete_slot(db: Session, slot_id: id) -> bool:
     db.commit()
     
     return True
-

--- a/chari-spot/backend/src/routers/parking.py
+++ b/chari-spot/backend/src/routers/parking.py
@@ -6,20 +6,24 @@ from crud import parking as crud
 from app.database import get_db
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
+from models import user as models
 
-router = APIRouter(
-    prefix="/parkings",
-    tags=["parking"],
-    dependencies=[Depends(get_current_user)],   # ← apply to all routes here
-)
+
+router = APIRouter(tags=["parking"])
+
 
 # 駐輪場の新規登録
-@router.post("/parkings/register", response_model=schemas.ParkingResponse)
-def create_parking(parking: schemas.ParkingCreate, db: Session = Depends(get_db)):
+@router.post("/register", response_model=schemas.ParkingResponse)
+def create_parking(
+    parking: schemas.ParkingCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user)
+):
     return crud.create_parking(db, parking)
 
+
 # 駐輪場一覧を取得（UTF-8 明示）
-@router.get("/parkings")
+@router.get("/all", response_model=list[schemas.ParkingResponse])
 def get_all_parkings(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     parkings = crud.get_parkings(db, skip=skip, limit=limit)
     return JSONResponse(
@@ -27,20 +31,32 @@ def get_all_parkings(skip: int = 0, limit: int = 100, db: Session = Depends(get_
         media_type="application/json; charset=utf-8"
     )
 
-# 駐輪場情報の更新
-@router.put("/parkings/update", response_model=schemas.ParkingResponse)
-def update_parking(slot: schemas.ParkingUpdate, db: Session = Depends(get_db)):
-    return crud.update_slot(db, slot)
-
-# 駐輪場の削除
-@router.delete("/parkings/delete/{id}")
-def delete_parking(id: int, db: Session = Depends(get_db)):
-    return crud.delete_slot(db, id)
 
 # 駐輪場の詳細取得
-@router.get("/parkings/{parking_id}", response_model=schemas.ParkingResponse)
+@router.get("/{parking_id}", response_model=schemas.ParkingResponse)
 def get_parking_detail(parking_id: int, db: Session = Depends(get_db)):
-    parking = crud.get_parking_by_id(db, parking_id)
+    parking = crud.get_parking(db, parking_id)
     if parking is None:
         raise HTTPException(status_code=404, detail="駐輪場が見つかりません")
     return parking
+
+
+# 駐輪場の詳細取得（ユーザーID指定）
+@router.get("/owned", response_model=schemas.ParkingResponse)
+def get_parking_by_owner(db: Session = Depends(get_db), user: models.User = Depends(get_current_user)):
+    parkings = crud.get_parking_by_owner(db, user.id)
+    if len(parkings) == 0:
+        raise HTTPException(status_code=404, detail="駐輪場が見つかりません")
+    return parkings
+
+
+# 駐輪場情報の更新
+@router.put("/update", response_model=schemas.ParkingResponse)
+def update_parking(slot: schemas.ParkingUpdate, db: Session = Depends(get_db)):
+    return crud.update_slot(db, slot)
+
+
+# 駐輪場の削除
+@router.delete("/delete/{id}")
+def delete_parking(id: int, db: Session = Depends(get_db)):
+    return crud.delete_slot(db, id)

--- a/chari-spot/backend/src/routers/user.py
+++ b/chari-spot/backend/src/routers/user.py
@@ -8,7 +8,7 @@ from app import auth
 from app.database import get_db
 from models import user as models
 
-router = APIRouter()
+router = APIRouter(tags=["user"])
 
 
 @router.post("/user/register", response_model=user.UserResponse)
@@ -34,22 +34,23 @@ async def login_for_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token = auth.create_access_token(
-        data={"sub": user.email},
+        data={"user_id": user.id},
         expires_delta=timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@router.get("/user/get/{id}", response_model=user.UserResponse)
-def update_user(id: int, db: Session = Depends(get_db)):
-    return crud.get_user(db, id)
+@router.get("/user/get", response_model=user.UserResponse)
+def get_user(db: Session = Depends(get_db), user: models.User = Depends(auth.get_current_user)):
+    return crud.get_user(db, user.id)
 
 
 @router.post("/user/update", response_model=user.UserResponse)
-def update_user(user: user.UserUpdate, db: Session = Depends(get_db)):
+def update_user(user_up: user.UserUpdate, db: Session = Depends(get_db), user: models.User = Depends(auth.get_current_user)):
+    user_up.id = user.id
     return crud.update_user(db, user)
 
 
-@router.delete("/user/delete/{id}")
-def update_user(id: int, db: Session = Depends(get_db)):
-    return crud.delete_user(db, id)
+@router.delete("/user/delete")
+def update_user(db: Session = Depends(get_db), user: models.User = Depends(auth.get_current_user)):
+    return crud.delete_user(db, user.id)


### PR DESCRIPTION
User ID can now be retrieved from bearer token.
Also changed parking related endpoints e.g. from "DELETE /parkings/parkings/{id}" to "DELETE /parkings/{id}". The frontend may need to change accordingly.